### PR TITLE
Process.MainModule should not ensure NotNull.

### DIFF
--- a/Microsoft.Research/Contracts/System/System.Diagnostics.Process.cs
+++ b/Microsoft.Research/Contracts/System/System.Diagnostics.Process.cs
@@ -59,11 +59,7 @@ namespace System.Diagnostics
 
     public ProcessModule MainModule
     {
-      get
-      {
-        Contract.Ensures(Contract.Result<ProcessModule>() != null);
-        return default(ProcessModule);
-      }
+      get;
     }
 
 #if false


### PR DESCRIPTION
As seen in http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Process.cs,493, Process.MainModule can return null for non Windows NT operating systems.  This includes Legacy versions of Windows, Xbox, Unix, MacOSX, etc.

The comment at http://referencesource.microsoft.com/#System/services/monitoring/system/diagnosticts/Process.cs,472 sheds a little light on the scenarios that could result in a null Main Module and includes "Possibly other" which means Code Contracts cannot reasonably assert that MainModule returns NotNull.